### PR TITLE
Fix incorrect hex offsets for setpoints 26–30°C

### DIFF
--- a/pelletstove.yaml
+++ b/pelletstove.yaml
@@ -210,27 +210,27 @@ climate:
             condition:
               lambda: 'return (id(Stove).target_temperature == 26);'
             then:
-              - uart.write: "\x1bRF21A065&"
+              - uart.write: "\x1bRF21A06C&"
         - if: 
             condition:
               lambda: 'return (id(Stove).target_temperature == 27);'
             then:
-              - uart.write: "\x1bRF21B066&"
+              - uart.write: "\x1bRF21B06D&"
         - if: 
             condition:
               lambda: 'return (id(Stove).target_temperature == 28);'
             then:
-              - uart.write: "\x1bRF21C067&"
+              - uart.write: "\x1bRF21C06E&"
         - if: 
             condition:
               lambda: 'return (id(Stove).target_temperature == 29);'
             then:
-              - uart.write: "\x1bRF21D068&"
+              - uart.write: "\x1bRF21D06F&"
         - if: 
             condition:
               lambda: 'return (id(Stove).target_temperature == 30);'
             then:
-              - uart.write: "\x1bRF21E069&"
+              - uart.write: "\x1bRF21E070&"
         - if: 
             condition:
               lambda: 'return (id(Stove).target_temperature < 15 && id(Stove).target_temperature > 30);'


### PR DESCRIPTION
Previously, the stove ignored commands above 25°C because the hex offsets were wrong.  Now each setpoint from 26 to 30°C uses the correct hex values, matching the device’s requirements.

Offsets vary by range:
- <16°C: 97
- 16–25°C: 75
- 26–31°C: 82
- ≥32°C: 60