### PR TITLE
Rename api services:/service: to actions:/action: in globals.yaml

### DIFF
--- a/components/globals.yaml
+++ b/components/globals.yaml
@@ -367,8 +367,8 @@ esphome:
         bridge.loop();
 
 api:
-  services:
-    - service: write
+  actions:
+    - action: write
       variables:
         command: string
       then:
@@ -392,7 +392,7 @@ api:
             else:
               - lambda: |-
                   id(debug).publish_state("Official app connected: write refused");
-    - service: write_raw
+    - action: write_raw
       variables:
         payload: string
       then:
@@ -416,7 +416,7 @@ api:
             else:
               - lambda: |-
                   id(debug).publish_state("Official app connected: write_raw refused");
-    - service: read_param
+    - action: read_param
       variables:
         param: int
       then:


### PR DESCRIPTION
## Problem

ESPHome's `api` component schema treats the old `services:` / `service:`
keys and the newer `actions:` / `action:` keys as **aliases** — both are
mapped internally to the same exclusion group. This package still uses
the old naming in `components/globals.yaml`:

```yaml
api:
  services:
    - service: write
      ...
    - service: write_raw
      ...
    - service: read_param
      ...
```

Any consumer of this package who also declares `api: actions:` in their
own config (or in another package they combine via `packages:`) — which
is the currently recommended key — gets a hard validation failure:

```
Failed config
api:
  two or more values in the same group of exclusion 'actions'.
  actions:
    - action: rescan_wifi
      ...
  services:
    - service: write
      ...
```

Neither block is wrong in isolation; the merged config simply ends up
with both `services:` and `actions:` present, which ESPHome's schema
rejects outright. This makes the package incompatible with any user
config that has already migrated to `actions:`.

## Solution

Rename the three service definitions (`write`, `write_raw`, `read_param`)
to use `actions:` / `action:` instead of `services:` / `service:`. This
is a pure rename — no behavior change, same variables, same `then:`
blocks — and matches current ESPHome conventions.

## Testing

Validated locally with ESPHome 2026.7.2 (`esphome config`) using a real
config that combines this package with another package declaring
`api: actions:` — config validation now passes, whereas it failed with
the `services:` naming before this change.